### PR TITLE
Update mpath.obo

### DIFF
--- a/mpath.obo
+++ b/mpath.obo
@@ -1,6 +1,7 @@
 format-version: 1.2
 date: 12:08:2013 12:25
 saved-by: Paul
+ontology: mpath
 auto-generated-by: OBO-Edit 2.3-beta5
 default-namespace: mouse_pathology.ontology
 namespace-id-rule: * MPATH:$sequence(3,0,999)$
@@ -3738,6 +3739,7 @@ id: MPATH:576
 name: trichofolliculoma
 def: "Basaloid neoplasm with numerous mature hair follicles and hair formation." [URL:http\://emice.nci.nih.gov/emice/mouse_models/organ_models/skin_models]
 relationship: part_of MPATH:575 ! basaloid follicular neoplasms
+is_a: MPATH:575 ! basaloid follicular neoplasms
 
 [Term]
 id: MPATH:577


### PR DESCRIPTION
- Made trichofolliculoma a [subclass](https://github.com/PaulNSchofield/mpath/issues/3) of basaloid follicular neoplasms
```
id: MPATH:576
name: trichofolliculoma
def: "Basaloid neoplasm with numerous mature hair follicles and hair formation." [URL:http\://emice.nci.nih.gov/emice/mouse_models/organ_models/skin_models]
relationship: part_of MPATH:575 ! basaloid follicular neoplasms
is_a: MPATH:575 ! basaloid follicular neoplasms
```
- Added `ontology: mpath` to the header to avoid ugly TEMP rendering of ontology id.